### PR TITLE
Updated docker-compose to fix npm install on dependent devices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./frontend:/frontend:delegated
-      - frontend_node_modules:/frontend/node_modules
     ports:
       - "3000:3000"
     networks:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^22.7.4",
-        "@types/react": "^18.3.10",
+        "@types/react": "^18.3.11",
         "@types/react-dom": "^18",
         "eslint": "^9.11.1",
         "postcss": "^8.4.47",
@@ -806,9 +806,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.10.tgz",
-      "integrity": "sha512-02sAAlBnP39JgXwkAq3PeU9DVaaGpZyF3MGcC0MKgQVkZor5IiiDAipVaxQHtDJAmO4GIy/rVBy/LzVj76Cyqg==",
+      "version": "18.3.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+      "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.7.4",
-    "@types/react": "^18.3.10",
+    "@types/react": "^18.3.11",
     "@types/react-dom": "^18",
     "eslint": "^9.11.1",
     "postcss": "^8.4.47",


### PR DESCRIPTION
 Even after reforking from the original branch and npm installing all the dependencies, I kept having the same swr issue:
 
![screenshot_2024-10-18_at_1 55 02___pm_720](https://github.com/user-attachments/assets/f78539b0-33cd-4177-b22e-16e176a8f093)

There was a lot of troubleshooting involved. I decided to check and see if it was a docker caching issue potentially. So, I checked to see what the container ID was for the frontend files:

![unnamed](https://github.com/user-attachments/assets/e6993eec-ee04-4a17-b2c5-63b1ef134c82)

Turns out, the SWR dependency was considered an "unmet" dependency:

![unnamed-1](https://github.com/user-attachments/assets/e44d54b0-e044-458e-9dbf-09451d9bf290)
![unnamed-2](https://github.com/user-attachments/assets/8dc29e2e-31bb-466f-a254-dd0c45c3488b)

So I changed the docker commands for running to see if things were cacheing weird. Instead of building as the change intended, the docker file built as per the previous run directions. Basically, the change I made didn't do anything. 

![unnamed-3](https://github.com/user-attachments/assets/ec777731-b78a-4c8b-a411-4fa53e531816)
![unnamed](https://github.com/user-attachments/assets/9ffd2b22-28f2-4a24-bf5e-cfccfcb1b9d6)

So I realized something weird was caching in the build. 

1. Firstly I changes the order of copy . . and npm run install, so that way the docker installs the dependencies first before copying anything from the cache:
 
![unnamed-1](https://github.com/user-attachments/assets/06f90518-3dfb-496e-a2e9-e9baba6b199d)
![unnamed-2](https://github.com/user-attachments/assets/87b58d49-1a38-44a1-a260-1a1788002e6e)

2. Secondly, I updated the docker compose file. 
 
![unnamed](https://github.com/user-attachments/assets/3f5c7737-a8b1-49b9-99f6-df03fbfe5c75)

There's an image and a named volume. The named volume is persistent external storage in docker, and is not affected by the commands running in the docker file. Since the node modules are persistent and unaffected by updates, this would require every new dependency to be manually installed through the interactive docker terminal which is not ideal. The image holds the updated node modules but is being overridden by the named volumes, so I removed the named volumes to avoid that issue moving forward. 

![Screenshot 2024-10-22 at 5 54 46 PM](https://github.com/user-attachments/assets/256fe244-4895-45b3-ac4d-5eddba081ed0)

 
 
 
